### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -9,6 +9,8 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Gez-Schegtel/30-Days-Of-Python/security/code-scanning/4](https://github.com/Gez-Schegtel/30-Days-Of-Python/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs a SonarQube scan and uses the `actions/checkout` action, it requires read access to the repository contents. Write permissions are not necessary for this workflow. Therefore, the `permissions` block should be set to `contents: read` at the job level to limit the scope of the `GITHUB_TOKEN` permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
